### PR TITLE
feat(Coupon): 쿠폰 발행과 만료 비즈니스로직 구현

### DIFF
--- a/src/coupon/domain/service.ts
+++ b/src/coupon/domain/service.ts
@@ -1,0 +1,74 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CouponHistoryRepository, CouponRepository } from './repository';
+import { Coupon, CouponHistory } from './model';
+import { CreateCouponDto, IssueCouponDto } from '../application/dto/dto';
+import { OnEvent } from '@nestjs/event-emitter';
+import { IssuedCouponEvent } from './events/issued-coupon.event';
+
+@Injectable()
+export class CouponService {
+  constructor(
+    @Inject('CouponRepository')
+    private readonly couponRepository: CouponRepository,
+    @Inject('CouponHistoryRepository')
+    private readonly couponHistoryRepository: CouponHistoryRepository,
+  ) {}
+
+  async createCoupon(args: CreateCouponDto) {
+    const coupon = new Coupon(args);
+    await this.couponRepository.createCoupon(coupon);
+  }
+
+  async issueCoupon(args: IssueCouponDto) {
+    await this.couponRepository
+      .getTransactionManager()
+      .transaction(async (transactionalEntityManager) => {
+        const coupon = await this.couponRepository.getCoupon(
+          args.couponId,
+          transactionalEntityManager,
+        );
+        coupon.issueCoupon({ userId: args.userId });
+        await this.couponRepository.updateCoupon(
+          coupon,
+          transactionalEntityManager,
+        );
+
+        coupon.releaseEvent();
+      });
+  }
+
+  @OnEvent('IssuedCouponEvent')
+  async handleOrderCreatedEvent(event: IssuedCouponEvent) {
+    try {
+      console.log('잉?');
+      await this.couponRepository
+        .getTransactionManager()
+        .transaction(async (transactionalEntityManager) => {
+          const { userId, couponId } = event;
+          const couponHistory = new CouponHistory({
+            couponId,
+            userId,
+            isUsed: false,
+            usedAt: null,
+          });
+          await this.couponHistoryRepository.createCouponHistory(
+            couponHistory,
+            transactionalEntityManager,
+          );
+        });
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  @OnEvent('IssuedCouponEvent')
+  async handleIssuedCouponEvent(event: IssuedCouponEvent) {
+    try {
+      console.log('받음?');
+      console.log(event);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+}
+/* 불리언 자체를 쓰기보단 풍부한 객체를 써라. 왜냐하면 변화에 대응하기 좋아진다. -> 프리미티브타입 반환을 지양 */

--- a/src/coupon/domain/service.ts
+++ b/src/coupon/domain/service.ts
@@ -37,10 +37,11 @@ export class CouponService {
       });
   }
 
+  async expireCoupon() {}
+
   @OnEvent('IssuedCouponEvent')
   async handleOrderCreatedEvent(event: IssuedCouponEvent) {
     try {
-      console.log('잉?');
       await this.couponRepository
         .getTransactionManager()
         .transaction(async (transactionalEntityManager) => {


### PR DESCRIPTION
작업 내역
쿠폰 발행

Coupon Model의 issueCoupon을 통해 쿠폰을 발행합니다.
쿠폰 발행에 실패하면 IssueCouponException을 발생시킵니다.
쿠폰 만료

Coupon Model의 expireCoupon을 통해 쿠폰을 만료시킵니다.
쿠폰 만료에 실패하면 winston으로 에러 로그를 적재하고, retry를 최대 3회 시도합니다.
의사결정 흐름
애그리거트의 상태 변경은 애그리거트 내부에서 이루어져야 한다고 생각하여 모델을 통해 상태 변경을 했습니다.
리소스 부하를 고려하여 쿠폰 만료 retry는 최대 3회로 제한하였고, 이후에는 별도의 배치 처리를 통해 만료시키고자 하였습니다.
배치는 추후 개발 예정입니다.
리뷰 포인트
쿠폰의 상태 변경 로직을 적절히 구현했는지 리뷰 부탁드립니다.
쿠폰 만료 실패를 적절한 방법으로 처리하고 있는지 리뷰 부탁드립니다.